### PR TITLE
feat(editing): use webview related uri for resource generation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ function createPanel(
   );
 
   // set content
-  panel.webview.html = provider.provideTextDocumentContent(uri);
+  panel.webview.html = provider.provideTextDocumentContent(uri, panel.webview);
 
   // set panel icons
   const {
@@ -68,10 +68,17 @@ function saveFile(uri: vscode.Uri, content: String) {
   fs.writeFileSync(docPath, content, { encoding: 'utf8' });
 }
 
-function refresh(editor: BpmnEditorPanel) {
-  const { resource, panel, provider } = editor;
+function refresh(
+  editor: BpmnEditorPanel
+) {
+  const {
+    resource,
+    panel,
+    provider
+  } = editor;
 
-  panel.webview.html = provider.provideTextDocumentContent(resource);
+  panel.webview.html =
+    provider.provideTextDocumentContent(resource, panel.webview);
 }
 
 function autoSaveIfConfigured(editorPanel: BpmnEditorPanel, expectedStates: string[]) {
@@ -188,7 +195,8 @@ export function activate(context: ExtensionContext) {
 
           panel.title = panel.title || getPanelTitle(resource, provider);
           panel.webview.options = getWebviewOptions(context, resource);
-          panel.webview.html = provider.provideTextDocumentContent(resource);
+          panel.webview.html =
+            provider.provideTextDocumentContent(resource, panel.webview);
 
           _registerPanel({ panel, resource, provider });
         }

--- a/src/features/editing/bpmnModelerBuilder.ts
+++ b/src/features/editing/bpmnModelerBuilder.ts
@@ -1,6 +1,4 @@
 'use strict';
-import * as vscode from 'vscode';
-
 export class BpmnModelerBuilder {
   contents: string;
   resources: any;
@@ -21,7 +19,8 @@ export class BpmnModelerBuilder {
       <html>
         <head>
           <meta charset="UTF-8" />
-          <title>BPMN Preview</title>
+
+          <title>BPMN Modeler</title>
 
           <!-- modeler distro -->
           <script src="${this.resources.modelerDistro}"></script>

--- a/src/test/mocks/index.ts
+++ b/src/test/mocks/index.ts
@@ -1,3 +1,19 @@
+const noop = () => {};
+
+const noopDisposable = (): Disposable => {
+    return new Disposable();
+};
+
+const noopThenable = (): Thenable<boolean> => {
+    return new Promise(resolve => {
+        resolve(true);
+    });
+};
+
+const noopUri = (): Uri => {
+    return new Uri();
+};
+
 export class ExtensionContext {
     extensionPath = 'foo/bar';
     subscriptions = [];
@@ -7,4 +23,48 @@ export class ExtensionContext {
     storagePath = null;
     globalStoragePath = null;
     logPath = null;
+}
+
+export class WebviewOptions {
+
+}
+
+export class Uri {
+    authority = '';
+    fragment = '';
+    fsPath = '';
+    path = '';
+    query = '';
+    scheme = '';
+    toJSON = noop;
+    with = noopUri;
+
+    constructor(options?: any) {
+        this.fsPath = options.fsPath;
+    }
+}
+
+export class Disposable {
+    dispose = noop;
+}
+
+export class Webview {
+    asWebviewUri = noopUri;
+    options = new WebviewOptions();
+    html = '';
+    onDidReceiveMessage = noopDisposable;
+    postMessage = noopThenable;
+    cspSource = '';
+
+    constructor(options?: any) {
+
+        if(options.resourcePath) {
+            this.asWebviewUri = () => {
+                return new Uri({
+                    fsPath: options.resourcePath
+                });
+            };
+        }
+
+    }
 }

--- a/src/test/suite/features/editingProvider.test.ts
+++ b/src/test/suite/features/editingProvider.test.ts
@@ -7,16 +7,21 @@ import * as vscode from 'vscode';
 
 import { EditingProvider } from '../../../features/editing/editingProvider';
 
-import { ExtensionContext } from '../../mocks';
+import { ExtensionContext, Webview } from '../../mocks';
 
 const TEST_FILE = path.join(__dirname, '../../', 'fixtures', 'simple.bpmn');
 
 suite('<editing.provider>', () => {
 
-    let provider:EditingProvider;
+    let provider: EditingProvider;
+    let webview: Webview;
 
     beforeEach(function() {
         const context = new ExtensionContext();
+
+        webview = new Webview({
+          resourcePath: TEST_FILE
+        });
 
          // @ts-ignore
         provider = new EditingProvider(context);
@@ -25,7 +30,8 @@ suite('<editing.provider>', () => {
     it('should provide content', async () => {
 
       // when
-      const content = provider.provideTextDocumentContent(vscode.Uri.file(TEST_FILE));
+      const content =
+        provider.provideTextDocumentContent(vscode.Uri.file(TEST_FILE), webview);
 
       // then
       expect(content).to.exist;


### PR DESCRIPTION
Update webview related resource generation by using proposed `asWebviewUri` API.

Closes #70