### PR TITLE
Enable direct command

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,12 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "when": "resourceLangId == bpmn",
+          "command": "extension.bpmn-io.edit"
+        }
+      ],
       "explorer/context": [
         {
           "when": "resourceLangId == bpmn",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
         }
       }
     ],
+    "keybindings": [
+      {
+        "command": "extension.bpmn-io.edit",
+        "key": "shift+ctrl+v",
+        "mac": "shift+cmd+v",
+        "when": "editorTextFocus && resourceLangId == bpmn"
+      }
+    ],
     "menus": {
       "commandPalette": [
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,8 +167,10 @@ export function activate(context: ExtensionContext) {
     } = COMMANDS;
 
     vscode.commands.registerCommand(EDIT_CMD, (uri: Uri) => {
-      if (!_revealIfAlreadyOpened(uri, editingProvider)) {
-        const panel = createPanel(context, uri, editingProvider);
+      const documentUri = getDocumentUri(uri);
+
+      if (documentUri && !_revealIfAlreadyOpened(documentUri, editingProvider)) {
+        const panel = createPanel(context, documentUri, editingProvider);
 
         _registerPanel(panel);
 
@@ -255,4 +257,10 @@ function getUri(...p: string[]): vscode.Uri {
 
 function sendMessage(message: String, webview: Webview) {
   webview.postMessage(message);
+}
+
+function getDocumentUri(uri?: Uri) {
+  const activeEditor = vscode.window.activeTextEditor;
+
+  return uri || activeEditor?.document.uri;
 }


### PR DESCRIPTION
This enables opening the modeler for the active opened file (in case it is a BPMN file) when
* executing via command palette (`CMD/CTRL + SHIFT + P` -> Open BPMN Modeler)
* executing via `CMD/CTRL + SHIFT + V` keyboard shortcut

Closes #61 
Closes #76 