### PR TITLE
Ensure File Opening Works on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -589,6 +589,12 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
+		"es6-object-assign": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+			"dev": true
+		},
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -1018,6 +1024,12 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.5",
@@ -1512,6 +1524,17 @@
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
 				"rechoir": "^0.6.2"
+			}
+		},
+		"shx": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/shx/-/shx-0.3.2.tgz",
+			"integrity": "sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==",
+			"dev": true,
+			"requires": {
+				"es6-object-assign": "^1.0.3",
+				"minimist": "^1.2.0",
+				"shelljs": "^0.8.1"
 			}
 		},
 		"sinon": {

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
     "vscode:prepublish": "npm run compile",
     "compile": "run-s compile:clean compile:ts compile:assets",
     "compile:ts": "tsc -p ./",
-    "compile:clean": "rm -rf out",
-    "compile:assets": "cp -r src/assets out",
+    "compile:clean": "shx rm -rf out",
+    "compile:assets": "shx cp -r src/assets out",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
     "test": "node ./out/test/runTest.js"
@@ -105,6 +105,7 @@
     "mocha": "^7.1.2",
     "npm-run-all": "^4.1.5",
     "shelljs": "^0.8.3",
+    "shx": "^0.3.2",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "tslint": "^5.20.1",

--- a/src/features/editing/editingProvider.ts
+++ b/src/features/editing/editingProvider.ts
@@ -18,11 +18,9 @@ export class EditingProvider {
 
   public provideTextDocumentContent(localResource: vscode.Uri, webview: vscode.Webview): string {
 
-    const webViewUri = webview.asWebviewUri(localResource);
+    const localDocumentPath = localResource.fsPath;
 
-    const docPath = webViewUri.fsPath;
-
-    const contents = fs.readFileSync(docPath, { encoding: 'utf8' });
+    const contents = fs.readFileSync(localDocumentPath, { encoding: 'utf8' });
 
     const builder = new BpmnModelerBuilder(contents, {
       modelerDistro: this.getUri(webview, 'node_modules', 'bpmn-js', 'dist', 'bpmn-modeler.development.js'),

--- a/src/test/suite/features/editingProvider.test.ts
+++ b/src/test/suite/features/editingProvider.test.ts
@@ -1,5 +1,10 @@
-import { expect } from 'chai';
+import * as chai from 'chai';
+
 import { it, beforeEach } from 'mocha';
+
+import * as sinonChai from 'sinon-chai';
+
+import { stub } from 'sinon';
 
 import * as path from 'path';
 
@@ -8,6 +13,12 @@ import * as vscode from 'vscode';
 import { EditingProvider } from '../../../features/editing/editingProvider';
 
 import { ExtensionContext, Webview } from '../../mocks';
+
+const fs = require('fs');
+
+chai.use(sinonChai);
+
+const expect = chai.expect;
 
 const TEST_FILE = path.join(__dirname, '../../', 'fixtures', 'simple.bpmn');
 
@@ -36,6 +47,20 @@ suite('<editing.provider>', () => {
       // then
       expect(content).to.exist;
       expect(content).to.include('const bpmnModeler = new BpmnJS');
+    });
+
+
+    it('should use local file path for fetching content', async () => {
+
+      // given
+      const fsSpy = stub(fs, 'readFileSync').returns('foo');
+
+      // when
+      provider.provideTextDocumentContent(vscode.Uri.file(TEST_FILE), webview);
+
+      // then
+      // assure no path modification has been made for webview optimization
+      expect(fsSpy).to.have.been.calledWith(TEST_FILE);
     });
 
 });


### PR DESCRIPTION
Closes #82 

* Ensures we're using the local file path for accessing the BPMN file contents instead of a WebView optimized one. It does not make sense to use a WebView path outside of a WebView
* Ensures commands like `rm` and `cp` work platform-specific 

How to test: simply open the Editor for any BPMN file by using the toolbar action or executing "CTRL+SHIFT+V"