### PR TITLE
chore: cache npm in github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Cache Node.js modules
+      uses: actions/cache@v2
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
     - name: Install dependencies
       run: npm install
     - name: Execute tests (Linux)


### PR DESCRIPTION
Cache npm files inside the GitHub action, to
* mirror the behavior [we have on Travis](https://github.com/bpmn-io/vs-code-bpmn-io/blob/master/.travis.yml#L20)
* make builds faster
* follow [best practices](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-nodejs#example-caching-dependencies)