### PR TITLE
add base64 decoding to pass BPMN to bpmnModeler

### DIFF
--- a/src/features/editing/bpmnModelerBuilder.ts
+++ b/src/features/editing/bpmnModelerBuilder.ts
@@ -144,7 +144,7 @@ export class BpmnModelerBuilder {
           }
 
           // open diagram
-          openDiagram('${this.contents}');
+          openDiagram(atob('${Buffer.from(this.contents).toString("base64")}'));
         </script>
       </body>
     `;


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
Close #99 

Use base64 encoding as a workaround to escape <script> tags when passing BPMN from view to Modeller. 