### PR TITLE
Closes #85

### DIFF
--- a/src/features/editing/editingProvider.ts
+++ b/src/features/editing/editingProvider.ts
@@ -22,7 +22,9 @@ export class EditingProvider {
 
     let contents = fs.readFileSync(localDocumentPath, { encoding: 'utf8' });
 
-    if(contents === "") contents = this.getDefaultBpmnDiagram(localDocumentPath);
+    if(contents === "") {
+      contents = this.getDefaultBpmnDiagram(localDocumentPath);
+    }
 
     const builder = new BpmnModelerBuilder(contents, {
       modelerDistro: this.getUri(webview, 'node_modules', 'bpmn-js', 'dist', 'bpmn-modeler.development.js'),
@@ -37,8 +39,7 @@ export class EditingProvider {
     return builder.buildModelerView();
   }
 
-  private getDefaultBpmnDiagram(fileName:string):string
-  {
+  private getDefaultBpmnDiagram(fileName:string):string {
     const file:string = path.basename(fileName);
 
     return `<?xml version="1.0" encoding="UTF-8"?>\n`

--- a/src/features/editing/editingProvider.ts
+++ b/src/features/editing/editingProvider.ts
@@ -39,7 +39,7 @@ export class EditingProvider {
 
   private getDefaultBpmnDiagram(fileName:string):string
   {
-    const file:string = path.parse(fileName).name;
+    const file:string = path.basename(fileName);
 
     return `<?xml version="1.0" encoding="UTF-8"?>\n`
     +`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" `

--- a/src/features/editing/editingProvider.ts
+++ b/src/features/editing/editingProvider.ts
@@ -53,6 +53,6 @@ export class EditingProvider {
     +`    <bpmndi:BPMNPlane id="${file}_BPMNPlane" bpmnElement="${file}_Process">\n`
     +`    </bpmndi:BPMNPlane>\n`
     +`  </bpmndi:BPMNDiagram>\n`
-    +`</bpmn:definitions>'`
+    +`</bpmn:definitions>`
   }
 }

--- a/src/features/editing/editingProvider.ts
+++ b/src/features/editing/editingProvider.ts
@@ -20,7 +20,9 @@ export class EditingProvider {
 
     const localDocumentPath = localResource.fsPath;
 
-    const contents = fs.readFileSync(localDocumentPath, { encoding: 'utf8' });
+    let contents = fs.readFileSync(localDocumentPath, { encoding: 'utf8' });
+
+    if(contents === "") contents = this.getDefaultBpmnDiagram(localDocumentPath);
 
     const builder = new BpmnModelerBuilder(contents, {
       modelerDistro: this.getUri(webview, 'node_modules', 'bpmn-js', 'dist', 'bpmn-modeler.development.js'),
@@ -33,5 +35,24 @@ export class EditingProvider {
     });
 
     return builder.buildModelerView();
+  }
+
+  private getDefaultBpmnDiagram(fileName:string):string
+  {
+    const file:string = path.parse(fileName).name;
+
+    return `<?xml version="1.0" encoding="UTF-8"?>\n`
+    +`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" `
+    +`   xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" `
+    +`   xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" `
+    +`   id="${file}_Definitions" `
+    +`   targetNamespace="http://bpmn.io/schema/bpmn">\n`
+    +`  <bpmn:process id="${file}_Process" isExecutable="true">\n`
+    +`  </bpmn:process>\n`
+    +`  <bpmndi:BPMNDiagram id="${file}_BPMNDiagram">\n`
+    +`    <bpmndi:BPMNPlane id="${file}_BPMNPlane" bpmnElement="${file}_Process">\n`
+    +`    </bpmndi:BPMNPlane>\n`
+    +`  </bpmndi:BPMNDiagram>\n`
+    +`</bpmn:definitions>'`
   }
 }


### PR DESCRIPTION
As a very simple fix for Issue #85, I just added a default blank diagram. So, if the developer creates a new file in VSCode then opens the blank document in the BPMN editor, we will paste in the minimal amount of XML to get the diagram editor working.

This corrects the previous behavior where the diagram editor would open but you could not add any diagram elements on the drawing surface.

Closes https://github.com/bpmn-io/vs-code-bpmn-io/issues/117
Closes #85 