### PR TITLE
Removed duplicated unit test

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -47,18 +47,6 @@ describe('extension', function() {
     });
 
 
-    it('should open as BPMN', async () => {
-
-      // when
-      await vscode.commands.executeCommand('vscode.open', SIMPLE_TEST_FILE);
-
-      // then
-      const extension = await getExtension(SIMPLE_TEST_FILE);
-
-      expect(extension, 'editor open').to.exist;
-    });
-
-
     it('should create new BPMN file', async () => {
 
       // when


### PR DESCRIPTION
### Proposed Changes

This change removes the test case 'should open as BPMN'. 
This test case is an exact duplicate of 'should open file' (same file, line 38).

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
