### PR TITLE
fix: document tracking issue when path of document changed

### DIFF
--- a/src/bpmn-editor.ts
+++ b/src/bpmn-editor.ts
@@ -351,13 +351,9 @@ export class BpmnEditor implements vscode.CustomEditorProvider<BpmnDocument> {
 
     document.onDidDispose(() => disposeAll(listeners));
 
-    // track documents across rename and deletion
+    // track documents
 
     this.documents.add(uri, document);
-
-    document.onDidRename(e => {
-      this.documents.rename(e.oldUri, e.newUri);
-    });
 
     document.onDidDispose(() => this.documents.remove(document.uri));
 
@@ -538,18 +534,6 @@ class DocumentCollection {
     const key = uri.toString();
 
     return this._documents.delete(key);
-  }
-
-  rename(oldUri: vscode.Uri, newUri: vscode.Uri) {
-
-    const document = this.get(oldUri);
-
-    if (!document) {
-      throw new Error('document not found');
-    }
-
-    this.remove(oldUri);
-    this.add(newUri, document);
   }
 
   add(uri: vscode.Uri, document: BpmnDocument) {


### PR DESCRIPTION
### Proposed Changes

This change removes the tracking of documents being renamed via `document.onDidRename`.
It seems that is actually not required (anymore) since the previous document gets removed and then added again. I check that for all use cases I could identify:

* Creating a new file / saving it
* Opening a file / saving to different location

Closes #176 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [X] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
