### PR TITLE
feat: add cross-BPMN editor copy-paste support (Closes #220)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/codicons": "^0.0.35",
-        "bpmn-js": "^18.1.2",
-        "bpmn-js-color-picker": "^0.7.1"
+        "bpmn-js": "^18.13.1",
+        "bpmn-js-color-picker": "^0.7.1",
+        "bpmn-js-native-copy-paste": "^0.3.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^29.0.0",
@@ -44,7 +45,7 @@
         "typescript-eslint": "^8.47.0"
       },
       "engines": {
-        "node": ">= 16",
+        "node": ">= 20.12",
         "vscode": "^1.79.2"
       }
     },
@@ -272,6 +273,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
       "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "license": "MIT",
       "dependencies": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
@@ -1664,7 +1666,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -2195,7 +2196,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2564,19 +2564,19 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/bpmn-js": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.1.2.tgz",
-      "integrity": "sha512-GtD/Zyu5foh+S74/PNNBs0ys1yiQb6LSuQjbUIzsCssNkbI/3IJH9k7y7AdRrZFoci+oFSeCRTwSCldZSPMpKw==",
-      "peer": true,
+      "version": "18.13.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.13.1.tgz",
+      "integrity": "sha512-atIcE8BS6hKEdZzXI4Mt2JG/+CVQEEOQ+H0krqrMdPXsSrwhsXUgoGDK0OEjMvaVNxr1NfGHtIqd2SpXsmSpug==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "bpmn-moddle": "^9.0.1",
-        "diagram-js": "^15.2.4",
-        "diagram-js-direct-editing": "^3.2.0",
-        "ids": "^1.0.5",
+        "bpmn-moddle": "^10.0.0",
+        "diagram-js": "^15.9.0",
+        "diagram-js-direct-editing": "^3.3.0",
+        "ids": "^3.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^4.1.1",
-        "min-dom": "^4.2.1",
-        "tiny-svg": "^3.1.2"
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0",
+        "tiny-svg": "^4.1.4"
       },
       "engines": {
         "node": "*"
@@ -2593,17 +2593,30 @@
         "bpmn-js": ">= 14"
       }
     },
-    "node_modules/bpmn-moddle": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
-      "integrity": "sha512-jO2P5RBx0cZCCd+imqhpNE5anttaYuGd71u76NEA/qMZwJSW1t5ETAtw9/E2InfiPU2w0TR8oxPyopJXRc9VQg==",
+    "node_modules/bpmn-js-native-copy-paste": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-native-copy-paste/-/bpmn-js-native-copy-paste-0.3.0.tgz",
+      "integrity": "sha512-qinthlYwiqlCak+TZB1niUPyzt/H1EuAfk2Whk2P8Jdj6LKyu3ADH08aGfC8aDhSd+sDrvdV6VEuIhwFmmSxRg==",
+      "license": "MIT",
       "dependencies": {
-        "min-dash": "^4.2.1",
-        "moddle": "^7.0.0",
-        "moddle-xml": "^11.0.0"
+        "min-dash": "^5.0.0"
+      },
+      "peerDependencies": {
+        "bpmn-js": ">= 18.10.0"
+      }
+    },
+    "node_modules/bpmn-moddle": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz",
+      "integrity": "sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==",
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "moddle": "^8.0.0",
+        "moddle-xml": "^12.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.12"
       }
     },
     "node_modules/brace-expansion": {
@@ -2772,7 +2785,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
       "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2904,6 +2916,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2964,11 +2977,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
-    },
-    "node_modules/component-event": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3254,32 +3262,33 @@
       }
     },
     "node_modules/diagram-js": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.2.4.tgz",
-      "integrity": "sha512-8v0U8AY6a5Vd6Cys5MdN7+yYRhs294/Q4ixkER/3v2ZPSbVCnK9XfbeYbB5QQfoCMkBnY7WBbLbcjvRNHTxnpw==",
-      "peer": true,
+      "version": "15.9.1",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.9.1.tgz",
+      "integrity": "sha512-2JsGmyeTo6o39beq2e/UkTfMopQSM27eXBUzbYQ+1m5VhEnQDkcjcrnRCjcObLMzzXSE/LSJyYhji90sqBFodQ==",
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
-        "clsx": "^2.1.0",
-        "didi": "^10.2.2",
+        "clsx": "^2.1.1",
+        "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^4.1.0",
-        "min-dom": "^4.2.1",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0",
         "object-refs": "^0.4.0",
-        "path-intersection": "^3.0.0",
-        "tiny-svg": "^3.1.2"
+        "path-intersection": "^4.1.0",
+        "tiny-svg": "^4.1.4"
       },
       "engines": {
         "node": "*"
       }
     },
     "node_modules/diagram-js-direct-editing": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.2.0.tgz",
-      "integrity": "sha512-+pyxeQGBSdLiZX0/tmmsm2qZSvm9YtVzod5W3RMHSTR7VrkUMD6E7EX/W9JQv3ebxO7oIdqFmytmNDDpSHnYEw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.3.0.tgz",
+      "integrity": "sha512-EjXYb35J3qBU8lLz5U81hn7wNykVmF7U5DXZ7BvPok2IX7rmPz+ZyaI5AEMiqaC6lpSnHqPxFcPgKEiJcAiv5w==",
+      "license": "MIT",
       "dependencies": {
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.2.1"
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0"
       },
       "engines": {
         "node": "*"
@@ -3289,11 +3298,12 @@
       }
     },
     "node_modules/didi": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
-      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-11.0.0.tgz",
+      "integrity": "sha512-PzCfRzQttvFpVcYMbSF7h8EsWjeJpVjWH4qDhB5LkMi1ILvHq4Ob0vhM2wLFziPkbUBi+PAo7ODbe2sacR7nJQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20.12"
       }
     },
     "node_modules/diff": {
@@ -3363,9 +3373,13 @@
       }
     },
     "node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domify/-/domify-3.0.0.tgz",
+      "integrity": "sha512-bs2yO68JDFOm6rKv8f0EnrM2cENduhRkpqOtt/s5l5JBA/eqGBZCzLPmdYoHtJ6utgLGgcBajFsEQbl12pT0lQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -3682,7 +3696,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4684,7 +4697,8 @@
     "node_modules/htm": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
@@ -4761,9 +4775,13 @@
       }
     },
     "node_modules/ids": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-3.0.2.tgz",
+      "integrity": "sha512-t6YJP4mdC+GHF96Nbis/4FEANhP/8VWmYMvUuYpXvSdrhg5hpIVbq2XZlOA3UWTbtdwPCi0q7jEXOdHkAnqOnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -4860,7 +4878,8 @@
     "node_modules/inherits-browser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw=="
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -5977,18 +5996,19 @@
       }
     },
     "node_modules/min-dash": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.2.tgz",
-      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
+      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "license": "MIT"
     },
     "node_modules/min-dom": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
-      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.3.0.tgz",
+      "integrity": "sha512-0w5FEBgPAyHhmFojW3zxd7we3D+m5XYS3E/06OyvxmbHJoiQVa4Nagj6RWvoAKYRw5xth6cP5TMePc5cR1M9hA==",
+      "license": "MIT",
       "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.2.1"
+        "domify": "^3.0.0",
+        "min-dash": "^5.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -6156,21 +6176,22 @@
       }
     },
     "node_modules/moddle": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
-      "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
-      "peer": true,
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.1.0.tgz",
+      "integrity": "sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==",
+      "license": "MIT",
       "dependencies": {
-        "min-dash": "^4.2.1"
+        "min-dash": "^5.0.0"
       }
     },
     "node_modules/moddle-xml": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
-      "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.0.0.tgz",
+      "integrity": "sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==",
+      "license": "MIT",
       "dependencies": {
-        "min-dash": "^4.0.0",
-        "saxen": "^10.0.0"
+        "min-dash": "^5.0.0",
+        "saxen": "^11.0.2"
       },
       "engines": {
         "node": ">= 18"
@@ -6399,6 +6420,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
       "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -6826,9 +6848,10 @@
       }
     },
     "node_modules/path-intersection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
-      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-4.1.0.tgz",
+      "integrity": "sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14.20"
       }
@@ -6905,7 +6928,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6946,9 +6968,10 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.24.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
-      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -7395,7 +7418,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7565,11 +7587,12 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/saxen": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
-      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.0.2.tgz",
+      "integrity": "sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.12"
       }
     },
     "node_modules/secretlint": {
@@ -8422,9 +8445,13 @@
       }
     },
     "node_modules/tiny-svg": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.3.tgz",
-      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-4.1.4.tgz",
+      "integrity": "sha512-cBaEACCbouYrQc9RG+eTXnPYosX1Ijqty/I6DdXovwDd89Pwu4jcmpOR7BuFEF9YCcd7/AWwasE0207WMK7hdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -8467,8 +8494,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -8623,7 +8649,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10164,7 +10189,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.47.0.tgz",
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -10483,8 +10507,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -10730,19 +10753,18 @@
       "dev": true
     },
     "bpmn-js": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.1.2.tgz",
-      "integrity": "sha512-GtD/Zyu5foh+S74/PNNBs0ys1yiQb6LSuQjbUIzsCssNkbI/3IJH9k7y7AdRrZFoci+oFSeCRTwSCldZSPMpKw==",
-      "peer": true,
+      "version": "18.13.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.13.1.tgz",
+      "integrity": "sha512-atIcE8BS6hKEdZzXI4Mt2JG/+CVQEEOQ+H0krqrMdPXsSrwhsXUgoGDK0OEjMvaVNxr1NfGHtIqd2SpXsmSpug==",
       "requires": {
-        "bpmn-moddle": "^9.0.1",
-        "diagram-js": "^15.2.4",
-        "diagram-js-direct-editing": "^3.2.0",
-        "ids": "^1.0.5",
+        "bpmn-moddle": "^10.0.0",
+        "diagram-js": "^15.9.0",
+        "diagram-js-direct-editing": "^3.3.0",
+        "ids": "^3.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^4.1.1",
-        "min-dom": "^4.2.1",
-        "tiny-svg": "^3.1.2"
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0",
+        "tiny-svg": "^4.1.4"
       }
     },
     "bpmn-js-color-picker": {
@@ -10751,14 +10773,22 @@
       "integrity": "sha512-SsDKewfopMPFTETAS1ZUWNKZvnQ7OBsODVcFEL2GzrQusW1VtnoCB2wc2vOtcafLAUPoUaRnVx5gZNtvywnJQA==",
       "requires": {}
     },
-    "bpmn-moddle": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
-      "integrity": "sha512-jO2P5RBx0cZCCd+imqhpNE5anttaYuGd71u76NEA/qMZwJSW1t5ETAtw9/E2InfiPU2w0TR8oxPyopJXRc9VQg==",
+    "bpmn-js-native-copy-paste": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-native-copy-paste/-/bpmn-js-native-copy-paste-0.3.0.tgz",
+      "integrity": "sha512-qinthlYwiqlCak+TZB1niUPyzt/H1EuAfk2Whk2P8Jdj6LKyu3ADH08aGfC8aDhSd+sDrvdV6VEuIhwFmmSxRg==",
       "requires": {
-        "min-dash": "^4.2.1",
-        "moddle": "^7.0.0",
-        "moddle-xml": "^11.0.0"
+        "min-dash": "^5.0.0"
+      }
+    },
+    "bpmn-moddle": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz",
+      "integrity": "sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==",
+      "requires": {
+        "min-dash": "^5.0.0",
+        "moddle": "^8.0.0",
+        "moddle-xml": "^12.0.0"
       }
     },
     "brace-expansion": {
@@ -10866,8 +10896,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
       "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "chalk": {
       "version": "5.3.0",
@@ -10996,11 +11025,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
-    },
-    "component-event": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -11179,35 +11203,34 @@
       "optional": true
     },
     "diagram-js": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.2.4.tgz",
-      "integrity": "sha512-8v0U8AY6a5Vd6Cys5MdN7+yYRhs294/Q4ixkER/3v2ZPSbVCnK9XfbeYbB5QQfoCMkBnY7WBbLbcjvRNHTxnpw==",
-      "peer": true,
+      "version": "15.9.1",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.9.1.tgz",
+      "integrity": "sha512-2JsGmyeTo6o39beq2e/UkTfMopQSM27eXBUzbYQ+1m5VhEnQDkcjcrnRCjcObLMzzXSE/LSJyYhji90sqBFodQ==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
-        "clsx": "^2.1.0",
-        "didi": "^10.2.2",
+        "clsx": "^2.1.1",
+        "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^4.1.0",
-        "min-dom": "^4.2.1",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0",
         "object-refs": "^0.4.0",
-        "path-intersection": "^3.0.0",
-        "tiny-svg": "^3.1.2"
+        "path-intersection": "^4.1.0",
+        "tiny-svg": "^4.1.4"
       }
     },
     "diagram-js-direct-editing": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.2.0.tgz",
-      "integrity": "sha512-+pyxeQGBSdLiZX0/tmmsm2qZSvm9YtVzod5W3RMHSTR7VrkUMD6E7EX/W9JQv3ebxO7oIdqFmytmNDDpSHnYEw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.3.0.tgz",
+      "integrity": "sha512-EjXYb35J3qBU8lLz5U81hn7wNykVmF7U5DXZ7BvPok2IX7rmPz+ZyaI5AEMiqaC6lpSnHqPxFcPgKEiJcAiv5w==",
       "requires": {
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.2.1"
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0"
       }
     },
     "didi": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
-      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w=="
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-11.0.0.tgz",
+      "integrity": "sha512-PzCfRzQttvFpVcYMbSF7h8EsWjeJpVjWH4qDhB5LkMi1ILvHq4Ob0vhM2wLFziPkbUBi+PAo7ODbe2sacR7nJQ=="
     },
     "diff": {
       "version": "8.0.2",
@@ -11251,9 +11274,9 @@
       }
     },
     "domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domify/-/domify-3.0.0.tgz",
+      "integrity": "sha512-bs2yO68JDFOm6rKv8f0EnrM2cENduhRkpqOtt/s5l5JBA/eqGBZCzLPmdYoHtJ6utgLGgcBajFsEQbl12pT0lQ=="
     },
     "domutils": {
       "version": "3.2.2",
@@ -11486,7 +11509,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12212,9 +12234,9 @@
       }
     },
     "ids": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-3.0.2.tgz",
+      "integrity": "sha512-t6YJP4mdC+GHF96Nbis/4FEANhP/8VWmYMvUuYpXvSdrhg5hpIVbq2XZlOA3UWTbtdwPCi0q7jEXOdHkAnqOnw=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -13027,18 +13049,17 @@
       "optional": true
     },
     "min-dash": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.2.tgz",
-      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
+      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw=="
     },
     "min-dom": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
-      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.3.0.tgz",
+      "integrity": "sha512-0w5FEBgPAyHhmFojW3zxd7we3D+m5XYS3E/06OyvxmbHJoiQVa4Nagj6RWvoAKYRw5xth6cP5TMePc5cR1M9hA==",
       "requires": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.2.1"
+        "domify": "^3.0.0",
+        "min-dash": "^5.0.0"
       }
     },
     "minimatch": {
@@ -13165,21 +13186,20 @@
       }
     },
     "moddle": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
-      "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
-      "peer": true,
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.1.0.tgz",
+      "integrity": "sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==",
       "requires": {
-        "min-dash": "^4.2.1"
+        "min-dash": "^5.0.0"
       }
     },
     "moddle-xml": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
-      "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.0.0.tgz",
+      "integrity": "sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==",
       "requires": {
-        "min-dash": "^4.0.0",
-        "saxen": "^10.0.0"
+        "min-dash": "^5.0.0",
+        "saxen": "^11.0.2"
       }
     },
     "ms": {
@@ -13620,9 +13640,9 @@
       "dev": true
     },
     "path-intersection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
-      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-4.1.0.tgz",
+      "integrity": "sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -13674,8 +13694,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "pidtree": {
       "version": "0.6.0",
@@ -13696,9 +13715,9 @@
       "dev": true
     },
     "preact": {
-      "version": "10.24.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
-      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg=="
     },
     "prebuild-install": {
       "version": "7.1.3",
@@ -14012,7 +14031,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@rollup/rollup-android-arm-eabi": "4.53.3",
         "@rollup/rollup-android-arm64": "4.53.3",
@@ -14114,9 +14132,9 @@
       "dev": true
     },
     "saxen": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
-      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g=="
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.0.2.tgz",
+      "integrity": "sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA=="
     },
     "secretlint": {
       "version": "10.2.2",
@@ -14710,9 +14728,9 @@
       }
     },
     "tiny-svg": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.3.tgz",
-      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-4.1.4.tgz",
+      "integrity": "sha512-cBaEACCbouYrQc9RG+eTXnPYosX1Ijqty/I6DdXovwDd89Pwu4jcmpOR7BuFEF9YCcd7/AWwasE0207WMK7hdw=="
     },
     "tmp": {
       "version": "0.2.5",
@@ -14740,8 +14758,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "tunnel": {
       "version": "0.0.6",
@@ -14847,8 +14864,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "typescript-eslint": {
       "version": "8.47.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "engines": {
     "vscode": "^1.79.2",
-    "node": ">= 16"
+    "node": ">= 20.12"
   },
   "icon": "resources/logo_marketplace.png",
   "categories": [
@@ -135,7 +135,8 @@
   },
   "dependencies": {
     "@vscode/codicons": "^0.0.35",
-    "bpmn-js": "^18.1.2",
-    "bpmn-js-color-picker": "^0.7.1"
+    "bpmn-js": "^18.13.1",
+    "bpmn-js-color-picker": "^0.7.1",
+    "bpmn-js-native-copy-paste": "^0.3.0"
   }
 }

--- a/src/client/bpmn-editor.js
+++ b/src/client/bpmn-editor.js
@@ -9,6 +9,7 @@ import './bpmn-editor.css';
 import BpmnModeler from 'bpmn-js/lib/Modeler';
 
 import BpmnColorPickerModule from 'bpmn-js-color-picker';
+import NativeCopyPasteModule from 'bpmn-js-native-copy-paste';
 
 import { handleMacOsKeyboard } from './utils/macos-keyboard';
 
@@ -22,8 +23,13 @@ handleMacOsKeyboard();
 const modeler = new BpmnModeler({
   container: '#canvas',
   additionalModules: [
-    BpmnColorPickerModule
+    BpmnColorPickerModule,
+    NativeCopyPasteModule
   ]
+});
+
+modeler.get('eventBus').on('native-copy-paste:error', (event) => {
+  console.warn('Native copy-paste failed, falling back to local clipboard', event.error);
 });
 
 modeler.on('import.done', event => {


### PR DESCRIPTION
Closes #220

### Changes proposed in this PR:

Integrated the bpmn-js-native-copy-paste module into the Webview client.

Added fallback logging in case the Webview restricts native clipboard access, ensuring it gracefully falls back to the local clipboard.

### Testing:
Due to VS Code Webview sandbox limitations preventing automated OS-level clipboard testing, I have manually verified the cross-file native copy-paste functionality.

### UI/UX CHANGE:
![ezgif-40cc5c3fff470cd6](https://github.com/user-attachments/assets/bba4cea6-3b16-47c9-9826-6868f046c887)



### Checklist



- [x] * Contribution meets the definition of done*

- [x] * Pull request establishes context*

- [x] *Link to related issue: Closes #220*

- [x] *Brief textual description of the changes*

- [x] *Screenshots or short videos showing UI/UX changes*

- [x] *Steps to try out*